### PR TITLE
Add release generation steps to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
     name: Create Release Packages
     runs-on: ubuntu-latest
     needs: [build, test]
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/3-revamp-extension-for-cross-browser-compatibility-chrome-firefox-safari-edge'
+    if: startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Checkout Repository
@@ -137,12 +137,31 @@ jobs:
         id: version
         run: echo "version=$(cat version.json | jq -r '.version')" >> $GITHUB_OUTPUT
 
+      - name: Generate Release Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: release-packages-v${{ steps.version.outputs.version }}
           path: build/
           retention-days: 90
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release v${{ steps.version.outputs.version }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: true
+          prerelease: false
+          generate_release_notes: false
+          files: build/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Build Summary
         run: |


### PR DESCRIPTION
## Summary by Sourcery

Extend the GitHub Actions workflow to publish release artifacts automatically on tag creation, including changelog generation and GitHub Release creation.

CI:
- Trigger the release packaging job only on tag pushes instead of specific branches
- Generate a release changelog using mikepenz/release-changelog-builder-action
- Create a GitHub Release with the generated changelog and upload build artifacts